### PR TITLE
Create a source JAR using maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,18 @@
 							<target>${java.version}</target>
 						</configuration>
 					</plugin>
+					<plugin>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>3.0.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 				</plugins>
 			</build>
 			<repositories>


### PR DESCRIPTION
IDEs such as IntelliJ and Eclipse support downloading a corresponding JAR of source code for JARs containing class files. This is useful when debugging crosses into dependencies, and also allows IDEs to show Javadoc for the dependency's classes.