### PR TITLE
Throw missing exceptions

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/BinarySearchST.java
+++ b/src/main/java/edu/princeton/cs/algs4/BinarySearchST.java
@@ -272,7 +272,7 @@ public class BinarySearchST<Key extends Comparable<Key>, Value> {
      * @throws NoSuchElementException if this symbol table is empty
      */
     public Key min() {
-        if (isEmpty()) return null;
+        if (isEmpty()) throw new NoSuchElementException("called min() with empty symbol table");
         return keys[0]; 
     }
 
@@ -283,7 +283,7 @@ public class BinarySearchST<Key extends Comparable<Key>, Value> {
      * @throws NoSuchElementException if this symbol table is empty
      */
     public Key max() {
-        if (isEmpty()) return null;
+        if (isEmpty()) throw new NoSuchElementException("called max() with empty symbol table");
         return keys[n-1];
     }
 
@@ -296,7 +296,7 @@ public class BinarySearchST<Key extends Comparable<Key>, Value> {
      *        <em>n</em>–1
      */
     public Key select(int k) {
-        if (k < 0 || k >= n) return null;
+        if (k < 0 || k >= n) throw new IllegalArgumentException();
         return keys[k];
     }
 


### PR DESCRIPTION
Throw missing exceptions in min(), max(), and select().

If you merged this pull request, you probably are violating the convention which says that when a method is to return a key and there is no valid key to be returned, our convention is to return null.

Therefore, if this pull request isn't aligned with this convention (and it's), then you need to remove @throws tags from method description in  min(), max(), and select(), and just return null instead.

So, I'm waiting to confirm which one is reasonable; throw an exception, or remove the @throws tag and return null?