### PR TITLE
fix a typo in topological.java

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/Topological.java
+++ b/src/main/java/edu/princeton/cs/algs4/Topological.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- *  Compilation:  javac Topoological.java
+ *  Compilation:  javac Topological.java
  *  Execution:    java  Topological filename.txt delimiter
  *  Dependencies: Digraph.java DepthFirstOrder.java DirectedCycle.java
  *                EdgeWeightedDigraph.java EdgeWeightedDirectedCycle.java


### PR DESCRIPTION
When I was transcoding topological.java into python, I found an extra 'o'.