### PR TITLE
Fixed the mistake in the comment of BST.java

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/BST.java
+++ b/src/main/java/edu/princeton/cs/algs4/BST.java
@@ -339,7 +339,7 @@ public class BST<Key extends Comparable<Key>, Value> {
     } 
 
     /**
-     * Return the kth smallest key in the symbol table.
+     * Return the (k+1)th smallest key in the symbol table
      *
      * @param  k the order statistic
      * @return the {@code k}th smallest key in the symbol table


### PR DESCRIPTION
According to the book, select() method return the key of given rank k (the key such that
precisely k other keys in the BST are smaller). But the comment said returning the kth smallest key in the symbol table. It's actually the (k+1)th smallest key
Please review and let me know what you think. Thanks.