### PR TITLE
Path Compression feature in QuickUnionUF and WeightQuickUnionUF

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/QuickUnionUF.java
+++ b/src/main/java/edu/princeton/cs/algs4/QuickUnionUF.java
@@ -117,8 +117,10 @@ public class QuickUnionUF {
      */
     public int find(int p) {
         validate(p);
-        while (p != parent[p])
+        while (p != parent[p]) {
+            parent[p] = parent[parent[p]];
             p = parent[p];
+        }
         return p;
     }
 

--- a/src/main/java/edu/princeton/cs/algs4/WeightedQuickUnionUF.java
+++ b/src/main/java/edu/princeton/cs/algs4/WeightedQuickUnionUF.java
@@ -120,8 +120,10 @@ public class WeightedQuickUnionUF {
      */
     public int find(int p) {
         validate(p);
-        while (p != parent[p])
+        while (p != parent[p]) {
+            parent[p] = parent[parent[p]];
             p = parent[p];
+        }
         return p;
     }
 


### PR DESCRIPTION
I noticed while taking this course that Dr. Sedgewick shows the one line of code needed to allow these data structures to have path compression. While working through assignments, I saw that this line of code was missing from the implementation. I'm not sure if this was intentional but I thought since Dr. Sedgewick made mention of it in the video that it would be important to add. 
```
public int find(int p) {
   validate(p);
   while (p != parent[p]) {
      parent[p] = parent[parent[p]]; // Line in question
      p = parent[p];
    }
      return p;
}
```

EDIT: I realize now that I said self-balancing in the commit message. What I really meant was "path compression".