### PR TITLE
Fix #54 - RedBlackBST delete problem

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/RedBlackBST.java
+++ b/src/main/java/edu/princeton/cs/algs4/RedBlackBST.java
@@ -309,7 +309,7 @@ public class RedBlackBST<Key extends Comparable<Key>, Value> {
             if (isRed(h.left))
                 h = rotateRight(h);
             if (key.compareTo(h.key) == 0 && (h.right == null))
-                return null;
+                return h.left;
             if (!isRed(h.right) && !isRed(h.right.left))
                 h = moveRedRight(h);
             if (key.compareTo(h.key) == 0) {


### PR DESCRIPTION
This commit makes delete method return the node left child instead of null, which avoids deleting the whole left branch if it exists.