### PR TITLE
fix url linking to 5.5: Data Compression

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/Huffman.java
+++ b/src/main/java/edu/princeton/cs/algs4/Huffman.java
@@ -28,7 +28,7 @@ package edu.princeton.cs.algs4;
  *  ASCII alphabet.
  *  <p>
  *  For additional documentation,
- *  see <a href="https://algs4.cs.princeton.edu/55compress">Section 5.5</a> of
+ *  see <a href="https://algs4.cs.princeton.edu/55compression">Section 5.5</a> of
  *  <i>Algorithms, 4th Edition</i> by Robert Sedgewick and Kevin Wayne.
  *
  *  @author Robert Sedgewick


### PR DESCRIPTION
This fixes the URL leading to 5.5: Data Compression. Before this the URL was incorrect and linked to a non-existent page. 