### PR TITLE
fix Javadoc typo

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/Vector.java
+++ b/src/main/java/edu/princeton/cs/algs4/Vector.java
@@ -93,7 +93,7 @@ public class Vector {
     }
 
     /**
-     * Returns the do product of this vector with the specified vector.
+     * Returns the dot product of this vector with the specified vector.
      *
      * @param  that the other vector
      * @return the dot product of this vector and that vector


### PR DESCRIPTION
Fixes typo in Javadoc for method dot()