### PR TITLE
Fix: Draw.keyReleased used to call listener.keyPressed

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/Draw.java
+++ b/src/main/java/edu/princeton/cs/algs4/Draw.java
@@ -1619,7 +1619,7 @@ public final class Draw implements ActionListener, MouseListener, MouseMotionLis
 
         // notify all listeners
         for (DrawListener listener : listeners)
-            listener.keyPressed(e.getKeyCode());
+            listener.keyReleased(e.getKeyCode());
     }
 
 


### PR DESCRIPTION
A hopefully obvious fix for a bug that bothered me when trying to use listeners.