### PR TITLE
Bug fix for NFA not recognizing patterns outside of prefix.

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/NFA.java
+++ b/src/main/java/edu/princeton/cs/algs4/NFA.java
@@ -119,6 +119,7 @@ public class NFA {
                 throw new IllegalArgumentException("text contains the metacharacter '" + txt.charAt(i) + "'");
 
             Bag<Integer> match = new Bag<Integer>();
+            match.add(0);
             for (int v : pc) {
                 if (v == m) continue;
                 if ((regexp.charAt(v) == txt.charAt(i)) || regexp.charAt(v) == '.')
@@ -126,11 +127,13 @@ public class NFA {
             }
             dfs = new DirectedDFS(graph, match); 
             pc = new Bag<Integer>();
-            for (int v = 0; v < graph.V(); v++)
-                if (dfs.marked(v)) pc.add(v);
+            for (int v = 0; v < graph.V(); v++){
+                if (dfs.marked(v)){
+                    pc.add(v);
+                    if(v==m)    return true;
+                }
+            }
 
-            // optimization if no states reachable
-            if (pc.size() == 0) return false;
         }
 
         // check for accept state


### PR DESCRIPTION
There is a small glitch on the NFA.java implementation. Take for instance the example case on the comments:

*  % java NFA "(a|(bc)*d)*" abcbcbcdaaaabcbcdaaaddd
 *  true

If I add a prefix that does not belong to the expression and run it again, then I get:

java-algs4 NFA.java "(a|(bc)*d)*" XXXXXXXXXXXXXXXXXXXXXxabcbcbcdaaaabcbcdaaaddd
false

I think this happens because the automaton does not check if the first character of the regular expression can be matched after it fails to match anything in the previous iteration. My patch attempts to fix it by always adding state 0 of the automaton to the inner DFS call.