### PR TITLE
to fix issue #90 - A problem occurred when run build file build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,6 @@ bintray {
     }
 }
 
-task wrapper(type: Wrapper) {
-  gradleVersion = '2.4'
+wrapper {
+  gradleVersion = '2.6'
 }


### PR DESCRIPTION
# 1 no longer define your own wrapper and init tasks

You should no longer define your own wrapper and init tasks. Configure the existing tasks instead, for example by converting this:

```groovy
task wrapper(type: Wrapper) {
    ...
}
```

to this:

```groovy
wrapper {
    ...
}
```

see [4.8 Configure existing wrapper and init tasks](https://docs.gradle.org/current/userguide/upgrading_version_4.html#rel4.8:configure_internal_tasks)

# 2

Support for builds using Gradle versions older than 2.6 was removed in tooling API version 5.0. You are currently using Gradle version 2.4. You should upgrade your Gradle build to use Gradle 2.6 or later.