### PR TITLE
fixes dead links to booksite sec2.3

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/Quick.java
+++ b/src/main/java/edu/princeton/cs/algs4/Quick.java
@@ -33,7 +33,7 @@ package edu.princeton.cs.algs4;
  *  array and selecting the ith smallest element in an array using quicksort.
  *  <p>
  *  For additional documentation,
- *  see <a href="https://algs4.cs.princeton.edu/23quick">Section 2.3</a> of
+ *  see <a href="https://algs4.cs.princeton.edu/23quicksort">Section 2.3</a> of
  *  <i>Algorithms, 4th Edition</i> by Robert Sedgewick and Kevin Wayne.
  *
  *  @author Robert Sedgewick

--- a/src/main/java/edu/princeton/cs/algs4/Quick3way.java
+++ b/src/main/java/edu/princeton/cs/algs4/Quick3way.java
@@ -28,7 +28,7 @@ package edu.princeton.cs.algs4;
  *  array using quicksort with 3-way partitioning.
  *  <p>
  *  For additional documentation,
- *  see <a href="https://algs4.cs.princeton.edu/23quick">Section 2.3</a> of
+ *  see <a href="https://algs4.cs.princeton.edu/23quicksort">Section 2.3</a> of
  *  <i>Algorithms, 4th Edition</i> by Robert Sedgewick and Kevin Wayne.
  *
  *  @author Robert Sedgewick

--- a/src/main/java/edu/princeton/cs/algs4/QuickBentleyMcIlroy.java
+++ b/src/main/java/edu/princeton/cs/algs4/QuickBentleyMcIlroy.java
@@ -23,7 +23,7 @@ package edu.princeton.cs.algs4;
  *  3-way partitioning, Tukey's ninther, and cutoff to insertion sort).
  *  <p>
  *  For additional documentation,
- *  see <a href="https://algs4.cs.princeton.edu/23quick">Section 2.3</a> of
+ *  see <a href="https://algs4.cs.princeton.edu/23quicksort">Section 2.3</a> of
  *  <i>Algorithms, 4th Edition</i> by Robert Sedgewick and Kevin Wayne.
  *
  *  @author Robert Sedgewick

--- a/src/main/java/edu/princeton/cs/algs4/QuickX.java
+++ b/src/main/java/edu/princeton/cs/algs4/QuickX.java
@@ -19,7 +19,7 @@ package edu.princeton.cs.algs4;
  *  to insertion sort).
  *  <p>
  *  For additional documentation,
- *  see <a href="https://algs4.cs.princeton.edu/23quick">Section 2.3</a> of
+ *  see <a href="https://algs4.cs.princeton.edu/23quicksort">Section 2.3</a> of
  *  <i>Algorithms, 4th Edition</i> by Robert Sedgewick and Kevin Wayne.
  *
  *  @author Robert Sedgewick


### PR DESCRIPTION
This PR fixes four occurrences of link to booksite sec. 2.3 from https://algs4.cs.princeton.edu/23quick (which returns 404 error) to https://algs4.cs.princeton.edu/23quicksort.

Every other references to booksite sec. 2.3 are OK.

PS: After these changes, the corresponding javadoc lines are all 80-character long. Not sure if line-breaks are required or not.
