### PR TITLE
bugfix: KeyListener should not be added twice

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/Draw.java
+++ b/src/main/java/edu/princeton/cs/algs4/Draw.java
@@ -1389,7 +1389,6 @@ public final class Draw implements ActionListener, MouseListener, MouseMotionLis
         // ensure there is a window for listenting to events
         show();
         listeners.add(listener);
-        frame.addKeyListener(this);
         frame.addMouseListener(this);
         frame.addMouseMotionListener(this);
         frame.setFocusable(true); 


### PR DESCRIPTION
Hi, 
I found a bug in Draw.java, the detail is when a DrawListener added to the Draw obj, the KeyListener of frame is added twice, which causes key events be responsed twice. So I deleted the frame.addKeyListener(this) in addListener() method. 

Here is the test code which replicate the bug:

import edu.princeton.cs.algs4.DrawListener;
import edu.princeton.cs.algs4.StdOut;

public class TestDrawListener implements DrawListener {

    @Override
    public void mousePressed(double x, double y) {
        // TODO Auto-generated method stub        
    }

    @Override
    public void mouseDragged(double x, double y) {
        // TODO Auto-generated method stub
        
    }

    @Override
    public void mouseReleased(double x, double y) {
        // TODO Auto-generated method stub
        
    }

    @Override
    public void mouseClicked(double x, double y) {
        // TODO Auto-generated method stub
        
    }

    @Override
    public void keyTyped(char c) {
        // TODO Auto-generated method stub        
    }

    @Override
    public void keyPressed(int keycode) {
        // TODO Auto-generated method stub
        StdOut.println("key pressed:"+keycode);
    }

    @Override
    public void keyReleased(int keycode) {
        // TODO Auto-generated method stub
        
    }
    
    public static void main(String[] args) {
        Draw draw = new Draw();
        var listener = new TestDrawListener();
        draw.addListener(listener);
    }
}
