### PR TITLE
fix: NFA zero vertices exception

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/NFA.java
+++ b/src/main/java/edu/princeton/cs/algs4/NFA.java
@@ -124,6 +124,8 @@ public class NFA {
                 if ((regexp.charAt(v) == txt.charAt(i)) || regexp.charAt(v) == '.')
                     match.add(v+1); 
             }
+            if (match.isEmpty())  continue;
+
             dfs = new DirectedDFS(graph, match); 
             pc = new Bag<Integer>();
             for (int v = 0; v < graph.V(); v++)


### PR DESCRIPTION
DFS validateVertices will throw zero vertices exception when match is Empty.
So it should check before run search.

original code will throw exception in case that text not match regex:
> $ java -cp algs4-1.0.0.0.jar edu.princeton.cs.algs4.NFA "abc*" d
Exception in thread "main" java.lang.IllegalArgumentException: zero vertices
        at edu.princeton.cs.algs4.DirectedDFS.validateVertices(DirectedDFS.java:132)
        at edu.princeton.cs.algs4.DirectedDFS.<init>(DirectedDFS.java:73)
        at edu.princeton.cs.algs4.NFA.recognizes(NFA.java:129)
        at edu.princeton.cs.algs4.NFA.main(NFA.java:153)


