### PR TITLE
Remove alpha channel and fix jpg image write

### DIFF
--- a/src/main/java/edu/princeton/cs/algs4/StdDraw.java
+++ b/src/main/java/edu/princeton/cs/algs4/StdDraw.java
@@ -671,8 +671,8 @@ public final class StdDraw implements ActionListener, MouseListener, MouseMotion
     private static void init() {
         if (frame != null) frame.setVisible(false);
         frame = new JFrame();
-        offscreenImage = new BufferedImage(2*width, 2*height, BufferedImage.TYPE_INT_ARGB);
-        onscreenImage  = new BufferedImage(2*width, 2*height, BufferedImage.TYPE_INT_ARGB);
+        offscreenImage = new BufferedImage(2*width, 2*height, BufferedImage.TYPE_INT_RGB);
+        onscreenImage  = new BufferedImage(2*width, 2*height, BufferedImage.TYPE_INT_RGB);
         offscreen = offscreenImage.createGraphics();
         onscreen  = onscreenImage.createGraphics();
         offscreen.scale(2.0, 2.0);  // since we made it 2x as big
@@ -1772,30 +1772,10 @@ public final class StdDraw implements ActionListener, MouseListener, MouseMotion
         File file = new File(filename);
         String suffix = filename.substring(filename.lastIndexOf('.') + 1);
 
-        // png files
-        if ("png".equalsIgnoreCase(suffix)) {
+        // jpg and png files
+        if (suffix.matches("(?i)png|jpg")) {
             try {
                 ImageIO.write(onscreenImage, suffix, file);
-            }
-            catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
-        // need to change from ARGB to RGB for JPEG
-        // reference: http://archives.java.sun.com/cgi-bin/wa?A2=ind0404&L=java2d-interest&D=0&P=2727
-        else if ("jpg".equalsIgnoreCase(suffix)) {
-            WritableRaster raster = onscreenImage.getRaster();
-            WritableRaster newRaster;
-            newRaster = raster.createWritableChild(0, 0, width, height, 0, 0, new int[] {0, 1, 2});
-            DirectColorModel cm = (DirectColorModel) onscreenImage.getColorModel();
-            DirectColorModel newCM = new DirectColorModel(cm.getPixelSize(),
-                                                          cm.getRedMask(),
-                                                          cm.getGreenMask(),
-                                                          cm.getBlueMask());
-            BufferedImage rgbBuffer = new BufferedImage(newCM, newRaster, false,  null);
-            try {
-                ImageIO.write(rgbBuffer, suffix, file);
             }
             catch (IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Alpha channel is optional in PNGs, hence removed alpha channel since all the named colors are RGB triplets (i.e. without alpha channel) and refactored code to accommodate jpg and png image writer in a single case insensitive regex conditional.

fixes #111 